### PR TITLE
fix: checking password section in auth block

### DIFF
--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -1,6 +1,16 @@
 export const VSCODE_PROJECT_CONFIG = {
   project: '<your-key-here>',
   sonarURL: '<your-sonar-url>',
+  auth:
+  {
+    username: '<sonar-username>',
+    password: '<sonar-password>'
+  }
+};
+
+export const VSCODE_PROJECT_JSON_FORMAT_OPTIONS = {
+  spaces: 4,
+  EOL: "\n",
 };
 
 export const COMMANDS = {

--- a/src/helpers/file.helpers.ts
+++ b/src/helpers/file.helpers.ts
@@ -1,6 +1,7 @@
 import { ensureDir, ensureFile, outputJson, readJson } from 'fs-extra';
 import { commands } from 'vscode';
 import { VSCODE_PROJECT_CONFIG } from '../data/constants';
+import { VSCODE_PROJECT_JSON_FORMAT_OPTIONS } from '../data/constants';
 import { Config } from '../interfaces/config.interface';
 import { has } from '../utils/general.util';
 
@@ -12,9 +13,9 @@ const isConfigured = (config: Config) => {
   let isAuthConfigured = true;
   if (has(config, 'auth')) {
     const isAuthUsernameConfigured =
-      (has(config.auth, 'username') && config.auth?.username.includes('sonar-username')) ?? false;
+      (has(config.auth, 'username') && !config.auth?.username.includes('sonar-username'));
     const isAuthPasswordConfigured =
-      (has(config.auth, 'password') && config.auth?.username.includes('sonar-password')) ?? false;
+      (has(config.auth, 'password') && !config.auth?.password.includes('sonar-password'));
     isAuthConfigured = isAuthUsernameConfigured && isAuthPasswordConfigured;
   }
   return isProjectKeyConfigured && isSonarURLConfigured && isAuthConfigured;
@@ -22,7 +23,7 @@ const isConfigured = (config: Config) => {
 
 export const createDefaultConfigFile = async (path: string) => {
   try {
-    await outputJson(`${path}/.vscode/project.json`, VSCODE_PROJECT_CONFIG);
+    await outputJson(`${path}/.vscode/project.json`, VSCODE_PROJECT_CONFIG, VSCODE_PROJECT_JSON_FORMAT_OPTIONS);
     return VSCODE_PROJECT_CONFIG;
   } catch (error) {
     throw new Error('Failed to create config file');


### PR DESCRIPTION
fix: checking block for input data in auth to return correct state if all args are properly filled.

add: formatter for project.json configuration file, to do not write sample in one line.