### PR TITLE
Add possibility to collect metrics from branch or pullRequest analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,13 @@ production.
 1. Install the Extension and Make sure it is activated.
 2. Click on the SonarQube logo on the activity bar or run the command from Command Palette:
 
-```
-SonarQube: Get Report
-```
+    ```
+    SonarQube: Get Report
+    ```
 
 3. This will create a `project.json` file in `.vscode` folder.
 4. Make sure to add the details:
+
 
 ### Using Password Auth
 
@@ -50,8 +51,37 @@ SonarQube: Get Report
 }
 ```
 
-The `auth` is optional property. It's only required for private SonarQube projects. You can etither use the **
-username/password** based authentication or **token-based** authentication.
+### Using SonarQube pullRequest Analysis Metrics
+
+```json
+{
+  "project": "adisreyaj_compito",
+  "sonarURL": "https://sonarcloud.io",
+  "pullRequest": 212,
+  "auth": {
+    "token": ""
+  }
+}
+```
+
+### Using SonarQube branch Analysis Metrics
+
+```json
+{
+  "project": "adisreyaj_compito",
+  "sonarURL": "https://sonarcloud.io",
+  "branch": "bugfix/fixMe",
+  "auth": {
+    "token": ""
+  }
+}
+```
+
+| Optional property | Description |
+| ----------------- | ----------- | 
+| `auth`            | Its only required for private SonarQube projects. The `auth` can be done via combination of `username` and `password` or `token`. Please look at sample configuration body file described above. |
+| `branch`          | It should be added if you want to collect metrics from [SonarQube branch analysis](https://docs.sonarqube.org/latest/branches/overview/) under project. |
+| `pullRequest`     | It should be added if you want to collect metrics from [SonarQube pullRequest analysis](https://docs.sonarqube.org/latest/analysis/pull-request/) under project. |
 
 5. Run the command again and you should see the report on the SonarQube section in the activity bar.
 

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -3,10 +3,13 @@ export const VSCODE_PROJECT_CONFIG = {
     'The authentication can be proceed in two ways. Using combination of username and password or token. The project.json which contains two of them at once is invalid.',
   project: '<your-key-here>',
   sonarURL: '<your-sonar-url>',
-  auth: {
+  pullRequest: '<optional-pull-request-id>',
+  branch: '<optional-branch-name>',
+  auth:
+  {
     username: '<sonar-username>',
-    password: '<sonar-password>',
-  },
+    password: '<sonar-password>'
+  }
 };
 
 export const VSCODE_PROJECT_JSON_FORMAT_OPTIONS = {

--- a/src/helpers/file.helpers.ts
+++ b/src/helpers/file.helpers.ts
@@ -54,6 +54,23 @@ export const isConfigured = (config: Config) => {
     isAuthConfigured,
     authType: type,
   };
+}
+
+export function isPullRequestOrBranchConfigured(config: Config) {
+  const isBranchConfigured = has(config, 'branch') &&
+    !config.branch?.includes('optional-branch-name');
+
+  const isPullRequestConfigured = has(config, 'pullRequest') &&
+    !config.pullRequest?.includes('optional-pull-request-id');
+
+  if ( isBranchConfigured || isPullRequestConfigured) {
+    // Give pullRequest highest priority
+    if ( isPullRequestConfigured ) {
+      return { pullRequest: config.pullRequest };
+    }
+
+    return { branch: config.branch };
+  }
 };
 
 export const createDefaultConfigFile = async (path: string) => {

--- a/src/helpers/sonar.helper.ts
+++ b/src/helpers/sonar.helper.ts
@@ -63,13 +63,28 @@ export async function getMetrics(config: Config) {
         metricKeys: METRICS_TO_FETCH,
       };
 
-      const data = await sonarClient.measures.component({...inputData, ...branchOrPullRequest});
+      const data:any = await sonarClient.measures.component({...inputData, ...branchOrPullRequest});
       if (data && data.metrics) {
         return parseResponse(data.component.measures, data?.metrics);
+      }
+      else if('errors' in data) {
+          let errorMessage = `SonarQube Error : ${data.errors[0].msg}`;
+          vscode.window.showErrorMessage(errorMessage);
       }
     }
     return null;
   } catch (error) {
+    let errorMessage = "SonarQube Status : Connection Error";
+    if (error instanceof Error) {
+      errorMessage = error.message;
+    }
+    if (errorMessage.includes('reason')) {
+      let reason = errorMessage.split('reason:')[1];
+      if (reason.includes('getaddrinfo ENOTFOUND')) {
+        reason = reason.replace('getaddrinfo ENOTFOUND', 'Cannot access to SQ server :')
+      }
+      vscode.window.showErrorMessage(reason)
+    }
     return null;
   }
 }

--- a/src/helpers/sonar.helper.ts
+++ b/src/helpers/sonar.helper.ts
@@ -5,7 +5,7 @@ import { Client, MeasuresRequest, MeasuresResponse, SonarQubeSDKAuth } from 'son
 import * as vscode from 'vscode';
 import { METRICS_TO_FETCH, RATING_VALUE_MAP } from '../data/constants';
 import { Config } from '../interfaces/config.interface';
-import { isConfigured } from './file.helpers';
+import { isConfigured, isPullRequestOrBranchConfigured } from './file.helpers';
 
 let client: Client | null = null;
 
@@ -52,12 +52,18 @@ export const sonarSDKClient = (config: Config) => {
 export async function getMetrics(config: Config) {
   try {
     const sonarClient = sonarSDKClient(config);
+
     if (sonarClient) {
-      const data = await sonarClient.measures.component({
+      // Collect pullRequest or branch configuration
+      const branchOrPullRequest = isPullRequestOrBranchConfigured(config);
+
+      const inputData = {
         component: config.project,
         additionalFields: [MeasuresRequest.MeasuresRequestAdditionalField.metrics],
         metricKeys: METRICS_TO_FETCH,
-      });
+      };
+
+      const data = await sonarClient.measures.component({...inputData, ...branchOrPullRequest});
       if (data && data.metrics) {
         return parseResponse(data.component.measures, data?.metrics);
       }

--- a/src/interfaces/config.interface.ts
+++ b/src/interfaces/config.interface.ts
@@ -7,5 +7,7 @@ interface AuthConfig {
 export interface Config {
   project: string;
   sonarURL: string;
+  branch?: string;
+  pullRequest?: string;
   auth?: AuthConfig;
 }


### PR DESCRIPTION
Hi  @adisreyaj , @pedroresende

I would like to propose small extension to your plugin. I would like to extend it via adding possibility to collect metrics from pullRequest or branch analysis.

For instance if the end user would like to receive analysis from pullRequest, he might define new attribute pullRequest:
`
{
      "project": "adisreyaj_compito",
      "sonarURL": "https://sonarcloud.io",
      "pullRequest": 212,
      "auth": {
        "username": "",
        "password": ""
      }
    }
`
or branch:
`
{
      "project": "adisreyaj_compito",
      "sonarURL": "https://sonarcloud.io",
      "branch": "bugfix/FixMe",
      "auth": {
        "username": "",
        "password": ""
      }
    }
`

In case if both of attrs are added, the highest priority will have pullRequest, as mostly engineers will be interested to see potential issues which they deliver to master branch.

Please let me know if this feature looks okay for you.

Kind Regards,
Lucas