### PR TITLE
Add `href` to the displayed cards

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "sonarqube-status",
   "displayName": "SonarQube Project Status",
   "description": "Get the status of your project including the Build status, Static code analysis statuses and more...",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "engines": {
-    "vscode": "^1.61.0"
+    "vscode": "^1.82.0"
   },
   "categories": [
     "Other"
@@ -84,33 +84,33 @@
     "test-compile": "tsc -p ./"
   },
   "devDependencies": {
-    "@types/fs-extra": "^9.0.13",
-    "@types/humanize-duration": "^3.25.1",
-    "@types/lodash-es": "^4.17.6",
-    "@types/mocha": "^2.2.42",
-    "@types/node": "^10.17.60",
-    "@types/vscode": "^1.61.0",
-    "@typescript-eslint/eslint-plugin": "^5.0.0",
-    "@typescript-eslint/parser": "^5.0.0",
-    "copy-webpack-plugin": "^9.0.1",
-    "eslint": "^7.32.0",
-    "eslint-config-airbnb-base": "^14.2.1",
-    "eslint-config-prettier": "^8.3.0",
-    "eslint-import-resolver-typescript": "^2.5.0",
-    "eslint-plugin-import": "^2.25.2",
-    "prettier": "^2.6.2",
-    "ts-loader": "^5.4.5",
-    "typescript": "^4.4.4",
+    "@types/fs-extra": "^11.0.2",
+    "@types/humanize-duration": "^3.27.1",
+    "@types/lodash-es": "^4.17.9",
+    "@types/mocha": "^10.0.2",
+    "@types/node": "^20.7.1",
+    "@types/vscode": "^1.82.0",
+    "@typescript-eslint/eslint-plugin": "^6.7.3",
+    "@typescript-eslint/parser": "^6.7.3",
+    "copy-webpack-plugin": "^11.0.0",
+    "eslint": "^8.50.0",
+    "eslint-config-airbnb-base": "^15.0.0",
+    "eslint-config-prettier": "^9.0.0",
+    "eslint-import-resolver-typescript": "^3.6.1",
+    "eslint-plugin-import": "^2.28.1",
+    "prettier": "^3.0.3",
+    "ts-loader": "^9.4.4",
+    "typescript": "^5.2.2",
     "vscode-test": "^1.6.1",
-    "webpack": "^5.58.2",
-    "webpack-cli": "^3.3.12"
+    "webpack": "^5.88.2",
+    "webpack-cli": "^5.1.4"
   },
   "dependencies": {
-    "fs-extra": "^10.0.0",
-    "humanize-duration": "^3.27.0",
+    "fs-extra": "^11.1.1",
+    "humanize-duration": "^3.30.0",
     "lodash-es": "^4.17.21",
-    "millify": "^4.0.0",
-    "node-fetch": "^3.1.1",
-    "sonarqube-sdk": "^0.3.0"
+    "millify": "^6.1.0",
+    "node-fetch": "^3.3.2",
+    "sonarqube-sdk": "file:../sonarqube-sdk"
   }
 }

--- a/src/helpers/sonar.helper.ts
+++ b/src/helpers/sonar.helper.ts
@@ -59,7 +59,7 @@ export async function getMetrics(config: Config) {
         metricKeys: METRICS_TO_FETCH,
       });
       if (data && data.metrics) {
-        return parseResponse(data.component.measures, data?.metrics);
+        return parseResponse(data.component.measures, data?.metrics, config);
       }
     }
     return null;
@@ -70,7 +70,8 @@ export async function getMetrics(config: Config) {
 
 function parseResponse(
   measures: MeasuresResponse.ComponentBaseMeasures[],
-  metrics: MeasuresResponse.ComponentMetric[]
+  metrics: MeasuresResponse.ComponentMetric[],
+  config: Config
 ) {
   const metricsMeta: Record<string, any> = metrics.reduce(
     (acc, curr) => ({ ...acc, [curr.key]: curr }),
@@ -81,6 +82,7 @@ function parseResponse(
     label: metricsMeta[item.metric].name,
     type: metricsMeta[item.metric].type,
     domain: metricsMeta[item.metric].domain,
+    url: `${config.sonarURL}/component_measures?metric=${item.metric}&id=${config.project}`,
     value: addFormatting(item.value, metricsMeta[item.metric]),
   }));
 

--- a/src/media/quick-stats.css
+++ b/src/media/quick-stats.css
@@ -50,12 +50,12 @@ h2 {
 }
 
 .item__value {
-  font-size: 0.875rem;
+  font-size: 1rem;
   font-weight: bold;
 }
 
 .item__label {
-  font-size: 0.575rem;
+  font-size: 0.875rem;
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;

--- a/src/media/quick-stats.js
+++ b/src/media/quick-stats.js
@@ -36,13 +36,15 @@
   function createCard(card) {
     return `
       <li class="quick-stats__list-item">
-      <header>
-        <p class="item__value">${card.value}</p>
-      </header>
-      <footer>
-        <p class="item__label">${card.label}</p>
-      </footer>
-    </li>
+      <a href="${card.url}">
+        <header>
+          <p class="item__value">${card.value}</p>
+        </header>
+      </a>
+        <footer>
+          <p class="item__label">${card.label}</p>
+        </footer>
+      </li>
     `;
   }
 


### PR DESCRIPTION
The extension is missing the possibilty to jump directly to the reel metrics in the provided URL site